### PR TITLE
adding an empty object to make sure we have clean objects

### DIFF
--- a/browser-es6.js
+++ b/browser-es6.js
@@ -11,7 +11,7 @@ var merge = require('lodash.merge');
  * Browser setttings.
  */
 
-module.exports = merge(base, {
+module.exports = merge({}, base, {
   env: {
     es6: true
   },

--- a/browser.js
+++ b/browser.js
@@ -11,11 +11,11 @@ var merge = require('lodash.merge');
  * Browser setttings.
  */
 
-module.exports = merge(base, {
-  'env': {
-    'browser': true
+module.exports = merge({}, base, {
+  env: {
+    browser: true
   },
-  'rules': {
+  rules: {
     // We frequently use console.log in development, and most of our libraries
     // will depend on linting success to run tests
     'no-console': 1

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
  */
 
 module.exports = {
-  'rules': {
+  rules: {
     'brace-style': [2, '1tbs', { 'allowSingleLine': true }],
     // We deal with snake_case in a lot of integrations, so disable this. But generally, follow this rule.
     'camelcase': 0,

--- a/node.js
+++ b/node.js
@@ -11,12 +11,11 @@ var merge = require('lodash.merge');
  * Node setttings.
  */
 
-module.exports = merge(base, {
-  'env': {
-    'node': true
+module.exports = merge({}, base, {
+  env: {
+    node: true
   },
-
-  'rules': {
+  rules: {
     'handle-callback-err': [1, '^(err|.+Err|error|.+Error)$'],
     'no-path-concat': 2,
     'no-sync': 1


### PR DESCRIPTION
This is coming in to clean up after eslint/eslint#2593 has been merged. If using multiple config envs, there was clobbering going on. This is our own due-dilligence. (that other PR addresses a bug eslint itself had)

Also dropped some unnecessary quotes.

/cc @ndhoule 
