### PR TITLE
Proposal: Requiring Spaces before Paren for Anon Functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
     'quotes': [2, 'single'],
     'radix': 2,
     'space-after-keywords': [2, 'always'],
-    'space-before-function-paren': [2, 'never'],
+    'space-before-function-paren': [2, { anonymous: 'always', named: 'never' }],
     // FIXME: ESLint doesn't support our function brace style (`function(){}`)
     // combined with our brace style (spaces, always) because it is, admittedly,
     // an inconsistent style. We can either change our style or write a custom


### PR DESCRIPTION
Currently, we require all functions to have no space before the parens. My proposal is to treat anonymous functions differently and instead require there to be a space before those parens.

This is **purely** aesthetic, and I've seen both styles used throughout our codebase. I just think this style is a little bit cleaner and the little extra whitespace gives a bit of balance.

Documentation for the ESLint Rule: [space-before-function-paren](http://eslint.org/docs/rules/space-before-function-paren)

**Current**

``` js
var hello = function() {};

domready(function() {
  // ...
});

return function() {
  // ...
};
```

**Proposed**

``` js
var hello = function () {};

domready(function () {
  // ...
});

return function () {
  // ...
};
```
