### PR TITLE
Add require as global to browser config

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -20,5 +20,8 @@ module.exports = merge({}, base, {
     // We frequently use console.log in development, and most of our libraries
     // will depend on linting success to run tests
     'no-console': 1
+  },
+  globals: {
+    require: false
   }
 });

--- a/browser.js
+++ b/browser.js
@@ -22,6 +22,8 @@ module.exports = merge({}, base, {
     'no-console': 1
   },
   globals: {
-    require: false
+    require: false,
+    module: true,
+    exports: true
   }
 });


### PR DESCRIPTION
With duo/component, we get `require` available to all client-side modules, so it's close enough to a global that this config change prevents errors about missing `require`.

I'd rather do this than adding `env: { node: true }`, since that also includes other non-browser globals like `global` and `process`.

/cc @ndhoule 
