### PR TITLE
Adds no-redeclare to our rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = {
     'no-multiple-empty-lines': [2, {'max': 2}],
     'no-nested-ternary': 2,
     'no-new-require': 2,
+    'no-redeclare': 2,
     'no-self-compare': 2,
     'no-shadow': 0,
     'no-throw-literal': 2,


### PR DESCRIPTION
When we deployed the app, a bug I introduced in segmentio/app@e3fa8a1886cb17e8a3765d70c215b42591729c0d prevented the page from loading for all users. We needed to rollback, and I introduced a fix segmentio/app@7fb59a0602d55d8095c249d583fab6ddd75a975d that has fixed the issue.

The problem was that I accidentally created a conflicting variable in the global scope for that module. (`var` up top, `function` way later) By adding `no-redeclare`, this will catch that same problem in the future. As noted in eslint/eslint#2953, this has already been fixed in `master`, so now we just await a new release. In the meantime, adding this rule will still be a good idea as it will catch other similar problems.
