### PR TITLE
Upgrade ESLint to 1.x

### DIFF
--- a/browser-es6.js
+++ b/browser-es6.js
@@ -26,6 +26,7 @@ module.exports = merge({}, base, {
     'no-extra-parens': 0,
     'react/jsx-quotes': [2, 'double'],
     'react/jsx-uses-react': [2, { pragma: 'element' }],
+    'react/jsx-no-undef': 2,
     'react/self-closing-comp': 2,
     'react/wrap-multilines': 2
   }

--- a/browser.js
+++ b/browser.js
@@ -16,7 +16,6 @@ module.exports = merge({}, base, {
     browser: true
   },
   rules: {
-    'global-strict': [0, 'always'],
     'new-cap': [ 2, { capIsNewExceptions: [ 'Emitter', 'Enumerable', 'Validator' ] } ],
     // We frequently use console.log in development, and most of our libraries
     // will depend on linting success to run tests

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = {
     'space-before-blocks': [1, 'always'],
     'space-before-function-paren': [2, 'never'],
     'space-in-parens': [2, 'never'],
-    'spaced-line-comment': [2, 'always'],
+    'spaced-comment': [2, 'always'],
     'strict': [2, 'global'],
     // FIXME: https://github.com/eslint/eslint/issues/2108
     // In order to really get benefit from this rule we need to either fix the

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lodash.merge": "^3.2.1"
   },
   "peerDependencies": {
-    "eslint": "0.x",
-    "eslint-plugin-react": "^2.3.0"
+    "eslint": "1.x",
+    "eslint-plugin-react": "^3.4.1"
   }
 }


### PR DESCRIPTION
This removes rules that were removed in ESLint@1 according to their [migration guide](http://eslint.org/docs/user-guide/migrating-to-1.0.0.html).

It also updates the versions pinned in our `package.json`. We'll bump `major` before releasing this.

/cc @ndhoule @lancejpollard @stevenmiller888
