### PR TITLE
using consistent style for quote-props

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = {
     'object-curly-spacing': [1, 'always'],
     'operator-linebreak': [2, 'before'],
     'padded-blocks': [2, 'never'],
-    'quote-props': [2, 'as-needed'],
+    'quote-props': [2, 'consistent-as-needed'],
     'quotes': [2, 'single'],
     'radix': 2,
     'space-after-keywords': [2, 'always'],


### PR DESCRIPTION
newer versions of eslint added the "consistent-as-needed" style to `quote-props`, which basically means we can enforce that an entire object is quoted if any 1 property requires quotes:

``` js
// quotes everywhere because of ".NET"
var langs = {
  'Android': 'android',
  'curl': 'curl',
  'Go': 'go',
  'iOS': 'ios',
  'Java': 'java',
  'JavaScript': 'js',
  'Node': 'node',
  'PHP': 'php',
  'Python': 'python',
  'Ruby': 'ruby',
  'Xamarin': 'Xamarin',
  '.NET': 'NET',
};

// current style
var langs = {
  Android: 'android',
  curl: 'curl',
  Go: 'go',
  iOS: 'ios',
  Java: 'java',
  JavaScript: 'js',
  Node: 'node',
  PHP: 'php',
  Python: 'python',
  Ruby: 'ruby',
  Xamarin: 'Xamarin',
  '.NET': 'NET',
};
```

I think it's easier to just keep the entire object consistent, rather than quoting some but not others. You can read more about this rule [here](http://eslint.org/docs/rules/quote-props).
