### PR TITLE
Warn on non-camelcased variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,7 @@
 module.exports = {
   rules: {
     'brace-style': [2, '1tbs', { 'allowSingleLine': true }],
-    // We deal with snake_case in a lot of integrations, so disable this. But generally, follow this rule.
-    'camelcase': 0,
+    'camelcase': [1, { 'properties': 'never' }],
     'comma-dangle': 2,
     'comma-style': [2, 'last'],
     'consistent-this': [0, 'self'],


### PR DESCRIPTION
Will not warn on camel-cased properties as APIs frequently
require snakecase.
