### PR TITLE
Require a `yield` within generator functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ module.exports = {
     'quote-props': [2, 'as-needed'],
     'quotes': [2, 'single'],
     'radix': 2,
+    'require-yield': 1,
     'semi': [2, 'always'],
     'space-after-keywords': [2, 'always'],
     'space-before-blocks': [1, 'always'],


### PR DESCRIPTION
This rule requires a yield statement within a generator function and
warns you if you don't have one. Basically prevents useless generators.

http://eslint.org/docs/rules/require-yield.html
