### PR TITLE
Restrict usage of `with` and `class`

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,11 @@ module.exports = {
     'no-octal': 2,
     'no-redeclare': 2,
     'no-regex-spaces': 2,
+    'no-restricted-syntax': [
+      1,
+      "ClassDeclaration",
+      "WithStatement"
+    ],
     'no-self-compare': 2,
     'no-shadow': 0,
     'no-sparse-arrays': 2,


### PR DESCRIPTION
You shouldn't be using `with` (it's an exception in strict mode anyway)
and we've all (pretty much?) agreed that class syntax is not what we
want to use.
