### PR TITLE
Warn on `==` usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'default-case': 2,
     'dot-location': [2, 'property'],
     'dot-notation': [2, { 'allowKeywords': true }],
+    'eqeqeq': [1, 'allow-null'],
     'generator-star-spacing': [2, 'after'],
     'guard-for-in': 2,
     'indent': [2, 2],


### PR DESCRIPTION
There's no reason for `==`. It has no advantage and worst case makes
code more confusing. We should make this an error eventually.

Allows usage of `val == null` because I know some people don't want to
live in a world without it.

http://eslint.org/docs/rules/eqeqeq.html
