### PR TITLE
disable no-confusing-arrow

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ module.exports = {
     "no-case-declarations": 2,
     "no-class-assign": 2,
     "no-cond-assign": 2,
-    "no-confusing-arrow": 2,
     "no-const-assign": 2,
     "no-constant-condition": 2,
     "no-control-regex": 2,


### PR DESCRIPTION
with `arrow-parens` enabled, this type of thing is far less ambiguous, and this error shows up in places it shouldn't for us.

/cc @ndhoule 
