### PR TITLE
Enable prefer-const at warn level

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -85,6 +85,7 @@ module.exports = {
     "object-curly-spacing": [2, "always"],
     "operator-linebreak": [2, "before"],
     "padded-blocks": [2, "never"],
+    "prefer-const": 1,
     "quote-props": [2, "as-needed"],
     "quotes": [2, "single"],
     "radix": 2,


### PR DESCRIPTION
Enabling this at warning level for now, we should increase it to error when we've had a chance to correct everywhere.

Closes #45.
