### PR TITLE
Warn on cyclomatic complexity > 11

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -8,6 +8,7 @@ module.exports = {
     "camelcase": [1, { "properties": "never" }],
     "comma-dangle": 2,
     "comma-style": [2, "last"],
+    "complexity": [1, 11],
     "consistent-this": [1, "self"],
     "constructor-super": 2,
     "curly": [2, "multi-line"],


### PR DESCRIPTION
`20` is ESLint's default. Haven't used the `complexity` rule much so we'll see how this pans out, I'm open to adjusting it up or down.

Set at a warning for now, I think that'll probably be best in the long term too.

Closes #8
