### PR TITLE
Update to ESLint 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/eslint-config",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "description": "Segment's ESLint configurations.",
   "author": "Segment <friends@segment.com>",
   "license": "MIT",
@@ -17,9 +17,9 @@
     "eslintconfig"
   ],
   "peerDependencies": {
-    "eslint": "2.x",
-    "eslint-plugin-mocha": "^2.0.0",
-    "eslint-plugin-react": "^4.0.0",
-    "eslint-plugin-require-path-exists": "^1.1.5"
+    "eslint": "^4.0.0",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-react": "^7.9.1",
+    "eslint-plugin-require-path-exists": "^1.1.8"
   }
 }


### PR DESCRIPTION
- Update plugins and ESLint peer dependencies to the latest version.
- Update package major version

According to the [3.0.0 migration guide](https://eslint.org/docs/user-guide/migrating-to-3.0.0) and the [4.0.0 migration guide](https://eslint.org/docs/user-guide/migrating-to-4.0.0) we don't have any breaking changes on the rules.

This is needed in order to get rid of `peerDependencies` warnings when using packages requiring recent version of `eslint` (like `prettier-eslint`).

Tested on `analytics.js-core`.

---

cc @f2prateek 